### PR TITLE
Adds support for parsing from an io.Reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,31 @@ for key, val := range exif.Tags {
 }
 ```
 
+If you just have the image available as an io.Reader, you can parse the
+EXIF header like this:
+
+```
+reader := exif.New()
+
+_, err = io.Copy(reader, data)
+
+// exif.FoundExifInData is a signal that the EXIF parser has all it needs,
+// it doesn't need to be given the whole image.
+if err != nil && err != exif.FoundExifInData {
+  t.Fatalf("Error loading bytes: %s", err.Error())
+}
+
+err := exif.Parse()
+
+if err != nil {
+  t.Fatalf("Error parsing EXIF: %s", err.Error())
+}
+
+for key, val := range exif.Tags {
+  fmt.Printf("%s: %s\n", key, val)
+}
+```
+
 There is currently no support for writing EXIF data to images, however if
 someone would care to make the effort it would be great.
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,10 +2,12 @@ package exif
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"testing"
 )
 
-func TestRead(t *testing.T) {
+func TestOpen(t *testing.T) {
 	exif := New()
 
 	// http://www.exif.org/samples/fujifilm-mx1700.jpg
@@ -15,6 +17,37 @@ func TestRead(t *testing.T) {
 		t.Fatalf("Error: %s", err.Error())
 	}
 
+	fmt.Println("----- Open")
+	for key, val := range exif.Tags {
+		fmt.Printf("%s: %s\n", key, val)
+	}
+}
+
+func TestWriteAndParse(t *testing.T) {
+	exif := New()
+
+	// http://www.exif.org/samples/fujifilm-mx1700.jpg
+	file, err := os.Open("_examples/resources/test.jpg")
+
+	if err != nil {
+		t.Fatalf("Error: %s", err.Error())
+	}
+
+	defer file.Close()
+
+	_, err = io.Copy(exif, file)
+
+	if err != nil && err != FoundExifInData {
+		t.Fatalf("Error: %s", err.Error())
+	}
+
+	err = exif.Parse()
+
+	if err != nil {
+		t.Fatalf("Error: %s", err.Error())
+	}
+
+	fmt.Println("----- Write and Parse")
 	for key, val := range exif.Tags {
 		fmt.Printf("%s: %s\n", key, val)
 	}


### PR DESCRIPTION
Useful for parsing multipart form uploads, which Go does not expose as
files.

Also updates the existing code not to save a pointer to the ExifData in
the struct (where it was unused) and changes to decrement the reference
of the ExifData rather than freeing it explicitly, so that it can clean
up its own memory.
