### PR TITLE
Avoid tag conflicts when finding tag titles.

### DIFF
--- a/main_c.c
+++ b/main_c.c
@@ -45,7 +45,7 @@ void import_entry(ExifEntry* entry, void* user_data) {
 
   value = new_exif_value();
 
-  strncpy(value->name, exif_tag_get_title(entry->tag), EXIF_VALUE_MAXLEN);
+  strncpy(value->name, exif_tag_get_title_in_ifd(entry->tag, exif_entry_get_ifd(entry)), EXIF_VALUE_MAXLEN);
   strncpy(value->value, exif_entry_get_value(entry, exif_text, EXIF_VALUE_MAXLEN), EXIF_VALUE_MAXLEN);
 
   push_exif_value(user_data, value);


### PR DESCRIPTION
Previously this used a deprecated function to find tag titles that
would fall victim to tag conflicts between IFDs. This now only looks
up the tag titles in the current IFD.
