### PR TITLE
Fix include with pkg-config

### DIFF
--- a/exif.go
+++ b/exif.go
@@ -24,6 +24,7 @@ package exif
 
 /*
 #cgo LDFLAGS: -lexif
+#cgo pkg-config: libexif
 
 #include <stdlib.h>
 #include <libexif/exif-data.h>


### PR DESCRIPTION
Seems the compiler can't find the proper includes when doing a standard 'go get'. Using pkg-config fixes that.
